### PR TITLE
coin_single is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Usage examples:
 >>> lcw.coins_single()
 Traceback (most recent call last):
   File "<stdin>", line 1, in <module>
-TypeError: coin_single() missing 1 required positional argument: 'code'
+TypeError: coins_single() missing 1 required positional argument: 'code'
 
 
 # same endpoint with the required parameters
@@ -90,8 +90,7 @@ TypeError: coin_single() missing 1 required positional argument: 'code'
 # optional parameters can be passed as defined in the API doc (https://livecoinwatch.github.io/lcw-api-docs/)
 >>> lcw.coins_single(currency="EUR", code="BTC", meta='true')
 # OR (also booleans can be used for boolean type arguments)
->>> lcw.coin_single(currency="EUR", code="BTC", meta=True)
-# both return the same thing
+>>> lcw.coins_single(currency="EUR", code="BTC", meta=True)
 {'name': 'Bitcoin', 'symbol': '₿', 'color': '#fa9e32', 'png32': 'https://lcw.nyc3.cdn.digitaloceanspaces.com/production/currencies/32/btc.png', 'png64': 'https://lcw.nyc3.cdn.digitaloceanspaces.com/production/currencies/64/btc.png', 'webp32': 'https://lcw.nyc3.cdn.digitaloceanspaces.com/production/currencies/32/btc.webp', 'webp64': 'https://lcw.nyc3.cdn.digitaloceanspaces.com/production/currencies/64/btc.webp', 'exchanges': 171, 'markets': 4483, 'pairs': 1604, 'allTimeHighUSD': 68780.77475755227, 'circulatingSupply': 18912906, 'totalSupply': 18912906, 'maxSupply': 21000000, 'rate': 43399.258910010154, 'volume': 17172466006, 'cap': 820806104234}
 ```
 

--- a/pylivecoinwatch/api.py
+++ b/pylivecoinwatch/api.py
@@ -128,3 +128,9 @@ class LiveCoinWatchAPI:
         payload = kwargs
         payload["codes"] = codes
         return self.__request(url, payload)
+
+    def coin_single(self, code, **kwargs):
+        url = "coins/single"
+        payload = kwargs
+        payload["code"] = code
+        return self.__request(url, payload)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -173,3 +173,9 @@ class TestWrapper(unittest.TestCase):
         for item in expected:
             for item2 in response:
                 self.assertIn(item, item2)
+
+    def test_coin_single(self):
+        expected = {"rate", "volume", "cap", "liquidity"}
+        response = self.lcw.coin_single(currency="USD", code="ETH", meta=False)
+        for item in expected:
+            self.assertIn(item, response)


### PR DESCRIPTION
however it is referenced in the README.
Added coin_single which does the same as coins_single.

Corrected a typo and removed coin_single from the README.
The naming convention should follow the LiveCoinWatch endpoint names.

Suggest coin_single be deprecated in favor of coins_single.